### PR TITLE
cameraservice: Avoid calling getSystemCameraKind if the camera was no…

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -261,8 +261,14 @@ void CameraService::pingCameraServiceProxy() {
     proxyBinder->pingForUserUpdate();
 }
 
-void CameraService::broadcastTorchModeStatus(const String8& cameraId, TorchModeStatus status,
-        SystemCameraKind systemCameraKind) {
+void CameraService::broadcastTorchModeStatus(const String8& cameraId, TorchModeStatus status) {
+    SystemCameraKind systemCameraKind = SystemCameraKind::PUBLIC;
+    status_t res = getSystemCameraKind(cameraId, &systemCameraKind);
+    if (res != OK) {
+        ALOGE("%s: Could not get system camera kind for camera id %s", __FUNCTION__,
+                cameraId.string());
+        return;
+    }
     Mutex::Autolock lock(mStatusListenerLock);
     for (auto& i : mListenerList) {
         if (shouldSkipStatusUpdates(systemCameraKind, i->isVendorListener(), i->getListenerPid(),
@@ -356,7 +362,7 @@ void CameraService::addStates(const String8 id) {
         Mutex::Autolock al(mTorchStatusMutex);
         mTorchStatusMap.add(id, TorchModeStatus::AVAILABLE_OFF);
 
-        broadcastTorchModeStatus(id, TorchModeStatus::AVAILABLE_OFF, deviceKind);
+        broadcastTorchModeStatus(id, TorchModeStatus::AVAILABLE_OFF);
     }
 
     updateCameraNumAndIds();
@@ -517,19 +523,12 @@ void CameraService::disconnectClient(const String8& id, sp<BasicClient> clientTo
 
 void CameraService::onTorchStatusChanged(const String8& cameraId,
         TorchModeStatus newStatus) {
-    SystemCameraKind systemCameraKind = SystemCameraKind::PUBLIC;
-    status_t res = getSystemCameraKind(cameraId, &systemCameraKind);
-    if (res != OK) {
-        ALOGE("%s: Could not get system camera kind for camera id %s", __FUNCTION__,
-                cameraId.string());
-        return;
-    }
     Mutex::Autolock al(mTorchStatusMutex);
-    onTorchStatusChangedLocked(cameraId, newStatus, systemCameraKind);
+    onTorchStatusChangedLocked(cameraId, newStatus);
 }
 
 void CameraService::onTorchStatusChangedLocked(const String8& cameraId,
-        TorchModeStatus newStatus, SystemCameraKind systemCameraKind) {
+        TorchModeStatus newStatus) {
     ALOGI("%s: Torch status changed for cameraId=%s, newStatus=%d",
             __FUNCTION__, cameraId.string(), newStatus);
 
@@ -578,7 +577,7 @@ void CameraService::onTorchStatusChangedLocked(const String8& cameraId,
             }
         }
     }
-    broadcastTorchModeStatus(cameraId, newStatus, systemCameraKind);
+    broadcastTorchModeStatus(cameraId, newStatus);
 }
 
 static bool hasPermissionsForSystemCamera(int callingPid, int callingUid) {
@@ -3848,7 +3847,7 @@ void CameraService::updateStatus(StatusInternal status, const String8& cameraId,
                             TorchModeStatus::AVAILABLE_OFF :
                             TorchModeStatus::NOT_AVAILABLE;
                     if (torchStatus != newTorchStatus) {
-                        onTorchStatusChangedLocked(cameraId, newTorchStatus, deviceKind);
+                        onTorchStatusChangedLocked(cameraId, newTorchStatus);
                     }
                 }
             }

--- a/services/camera/libcameraservice/CameraService.h
+++ b/services/camera/libcameraservice/CameraService.h
@@ -998,8 +998,7 @@ private:
     // handle torch mode status change and invoke callbacks. mTorchStatusMutex
     // should be locked.
     void onTorchStatusChangedLocked(const String8& cameraId,
-            hardware::camera::common::V1_0::TorchModeStatus newStatus,
-            SystemCameraKind systemCameraKind);
+            hardware::camera::common::V1_0::TorchModeStatus newStatus);
 
     // get a camera's torch status. mTorchStatusMutex should be locked.
     status_t getTorchStatusLocked(const String8 &cameraId,
@@ -1088,8 +1087,7 @@ private:
     static void pingCameraServiceProxy();
 
     void broadcastTorchModeStatus(const String8& cameraId,
-            hardware::camera::common::V1_0::TorchModeStatus status,
-            SystemCameraKind systemCameraKind);
+            hardware::camera::common::V1_0::TorchModeStatus status);
 
     void disconnectClient(const String8& id, sp<BasicClient> clientToDisconnect);
 


### PR DESCRIPTION
…t mapped yet

* By calling `getSystemCameraKind()` directly in
  `broadcastTorchModeStatus()` we ensure that previous calls to
  `getTorchStatusLocked` and `setTorchStatusLocked` had succeeded,
  meaning that the camera device is already present in mCameraStates.

  When the camera device is already mapped in mCameraStates
  calls to `getSystemCameraKind()` will avoid interrogating the
  CameraProviderManager, which was causing a deadlock
  upon attempting to lock mInterfaceLock.

Change-Id: I2aed9d53f13859d26efe6a8ab300afab6944f5f7